### PR TITLE
remove xvfb, fix loop, and refactor code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12.7-slim
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y --no-install-recommends wine wine32 xvfb systemd procps && \
+    apt-get install -y --no-install-recommends wine wine32 systemd procps && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/mohh-gps.service
+++ b/mohh-gps.service
@@ -2,10 +2,10 @@
 Description=Start MOHH GPS Instances
 
 [Service]
+KillMode=none
+Type=oneshot
 PassEnvironment=GPS_NAME GPS_PWD GPS_ADM_PWD GPS_PORT GPS_INSTANCES
 Environment=WINEDEBUG=-all
-Environment=WINEARCH=win32
-Environment=DISPLAY=:1
 WorkingDirectory=/var/www/mohh-gps
 ExecStart=/var/www/mohh-gps/start_gps_instances.sh
 StandardOutput=append:/var/log/mohh-gps/mohz.log

--- a/start_gps_instances.sh
+++ b/start_gps_instances.sh
@@ -5,13 +5,12 @@ if [ -z "$GPS_NAME" ] || [ -z "$GPS_PWD" ] || [ -z "$GPS_ADM_PWD" ]; then
     exit 1
 fi
 
-export GPS_NAME
-export GPS_PWD
-export GPS_ADM_PWD
 export GPS_PORT=${GPS_PORT:-3658}
 export GPS_INSTANCES=${GPS_INSTANCES:-1}
 
-GPS_PORT=$((GPS_PORT - 1))
+if [ ! -d "/root/.wine" ]; then
+   winecfg > /dev/null 2>&1
+fi
 
 start_instance() {
     sleep 5 # wait for the previous instance to start
@@ -24,10 +23,7 @@ start_instance() {
     wine /var/www/mohh-gps/mohz.exe -name:$GPS_NAME -pwd:$GPS_PWD -port:$port -adminpwd:$GPS_ADM_PWD -easerver &
 }
 
-Xvfb :0 -screen 0 1024x768x16 &
-winecfg > /dev/null 2>&1
-
-for i in $(seq 1 $GPS_INSTANCES); do
+for ((i = 0; i < GPS_INSTANCES; i++)); do
     port=$(($GPS_PORT + i))
     if ! pgrep -f "mohz.exe -name:$GPS_NAME -pwd:$GPS_PWD -port:$port" > /dev/null; then
         start_instance $port


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the code, including:

- Removed `xvfb` : Simplified the setup by removing Xvfb from the code, as it was unnecessary. This change also results in a reduced image size.
- Fixed Loop Issue: Ensured that the loop properly iterates even when `GPS_INSTANCES` is set to 1.
- Resolved Service Restart Problem: Corrected the issue where the service would fail to relaunch after 5 minutes of inactivity.
- Added Wine Configuration Check: Implemented a check to see if `winecfg` had already been executed to prevent unnecessary configurations.
- Refactored Code: Removed of unnecessary export statements.
